### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/patric_tools/amr.py
+++ b/patric_tools/amr.py
@@ -76,7 +76,7 @@ def get_last_metadata_update_date():
     """
     ftps = ftplib.FTP(PATRIC_FTP_BASE_URL.replace("ftp://", ""))
     ftps.login()
-    mod_time = ftps.sendcmd("MDTM %s" % PATRIC_FTP_AMR_METADATA_URL.replace(PATRIC_FTP_BASE_URL, "").replace("ftp://", "")[1:]).split()[1]
+    mod_time = ftps.sendcmd("MDTM {0!s}".format(PATRIC_FTP_AMR_METADATA_URL.replace(PATRIC_FTP_BASE_URL, "").replace("ftp://", "")[1:])).split()[1]
     return datetime.strptime(mod_time, '%Y%m%d%H%M%S')
 
 
@@ -92,7 +92,7 @@ def get_latest_metadata(outdir):
     """
     exception = download_file_from_url(PATRIC_FTP_AMR_METADATA_URL, outdir)
     if exception != '':
-        raise RuntimeError("Failed to download the latest AMR metadata: %s" % exception)
+        raise RuntimeError("Failed to download the latest AMR metadata: {0!s}".format(exception))
     return os.path.join(outdir, url_extract_file_name(PATRIC_FTP_AMR_METADATA_URL))
 
 

--- a/patric_tools/genomes.py
+++ b/patric_tools/genomes.py
@@ -37,7 +37,7 @@ def download_genome_contigs(patric_id, outdir=".", throttle=False):
     if throttle:
         sleep(2)  # Give that server a break!
     file_name = urljoin(PATRIC_FTP_GENOMES_FNA_URL, patric_id + ".fna")
-    logging.debug("Downloading contigs for genome %s (%s)" % (patric_id, file_name))
+    logging.debug("Downloading contigs for genome {0!s} ({1!s})".format(patric_id, file_name))
     return download_file_from_url(file_name, outdir=outdir)
 
 
@@ -63,7 +63,7 @@ def download_genome_patric_annotations(patric_id, outdir=".", throttle=False):
     if throttle:
         sleep(2)  # Give that server a break!
     file_name = urljoin(PATRIC_FTP_GENOMES_TAB_URL, patric_id + ".PATRIC.features.tab")
-    logging.debug("Downloading PATRIC annotations for genome %s (%s)" % (patric_id, file_name))
+    logging.debug("Downloading PATRIC annotations for genome {0!s} ({1!s})".format(patric_id, file_name))
     return download_file_from_url(file_name, outdir=outdir)
 
 
@@ -79,5 +79,5 @@ def get_latest_metadata(outdir):
     """
     exception = download_file_from_url(PATRIC_FTP_GENOMES_METADATA_URL, outdir)
     if exception != '':
-        raise RuntimeError("Failed to download the latest AMR metadata: %s" % exception)
+        raise RuntimeError("Failed to download the latest AMR metadata: {0!s}".format(exception))
     return os.path.join(outdir, url_extract_file_name(PATRIC_FTP_GENOMES_METADATA_URL))

--- a/patric_tools/utils.py
+++ b/patric_tools/utils.py
@@ -33,7 +33,7 @@ def download_file_from_url(url, outdir):
     url = url.strip()
     try:
         from os import system
-        system("wget --quiet -o /dev/null -O %s --continue --timeout 20 %s" % (os.path.join(outdir, url_extract_file_name(url)), url))
+        system("wget --quiet -o /dev/null -O {0!s} --continue --timeout 20 {1!s}".format(os.path.join(outdir, url_extract_file_name(url)), url))
         return ""
     except Exception as e:
         print e


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:aldro61:patric_tools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:aldro61:patric_tools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)